### PR TITLE
SF-2340 - Constrained typescript typeRoots to use local node_modules/@types directory only 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,9 +2012,9 @@
       }
     },
     "typescript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
       "dev": true
     },
     "user-home": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "rimraf": "^2.6.1",
     "ts-node": "^3.3.0",
     "tslint-microsoft-contrib": "^5.0.1",
-    "typescript": "^2.4.2"
+    "typescript": "^2.8.3"
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,7 +11,10 @@
 		"allowUnusedLabels" : false,
 		"allowUnreachableCode" : false,
 		"noUnusedLocals": true,
-		"noUnusedParameters": true
+		"noUnusedParameters": true,
+		"typeRoots": [
+			"../node_modules/@types"
+		]
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
This allows us to build skysync-design-system when included as a submodule, without the parent types conflicting.