### PR TITLE
SF-3148: Allow TimeZone to be passed into tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint": "tslint --config tslint.json 'src/**/*.ts' --exclude '**/node_modules/**'",
     "rebuild": "npm run clean && npm run build",
     "start": "node bin/skysync.js",
-    "test": "cross-env TS_NODE_PROJECT=./src/tsconfig.json mocha --timeout 10000 --compilers ts:ts-node/register src/**/*.test.ts && npm run lint",
+    "test": "cross-env TS_NODE_PROJECT=./src/tsconfig.json TIME_ZONE=Pacific/Chatham mocha --timeout 10000 --compilers ts:ts-node/register src/**/*.test.ts && npm run lint",
     "prepublishOnly": "npm run rebuild"
   },
   "bin": {

--- a/src/sdk/formatting/formatDate.test.ts
+++ b/src/sdk/formatting/formatDate.test.ts
@@ -1,93 +1,93 @@
 import { formatDate } from './formatDate';
 import expect = require('expect.js');
-import {timeZoneCode} from './testUtil';
+import {appendTimeZoneCode} from './testUtil';
 
 describe('formatDate', () => {
 	describe('relative', () => {
-		const now = new Date(`2016-04-10 12:00:00${timeZoneCode}`);
+		const now = new Date(appendTimeZoneCode('2016-04-10 12:00:00'));
 
 		it('should format seconds-distant dates', () => {
-			expect(formatDate(`2016-04-10 11:59:50${timeZoneCode}`, {now, allowRelative: true})).to.eql('Just now');
-			expect(formatDate(`2016-04-10 12:00:00${timeZoneCode}`, {now, allowRelative: true})).to.eql('Just now');
-			expect(formatDate(`2016-04-10 11:59:10${timeZoneCode}`, {now, allowRelative: true})).to.eql('1 minute ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 11:59:50'), {now, allowRelative: true})).to.eql('Just now');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 12:00:00'), {now, allowRelative: true})).to.eql('Just now');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 11:59:10'), {now, allowRelative: true})).to.eql('1 minute ago');
 		});
 
 		it('should format minutes-distant dates', () => {
-			expect(formatDate(`2016-04-10 11:59${timeZoneCode}`, {now, allowRelative: true})).to.eql('1 minute ago');
-			expect(formatDate(`2016-04-10 11:55${timeZoneCode}`, {now, allowRelative: true})).to.eql('5 minutes ago');
-			expect(formatDate(`2016-04-10 11:15:00${timeZoneCode}`, {now, allowRelative: true})).to.eql('45 minutes ago');
-			expect(formatDate(`2016-04-10 11:10:00${timeZoneCode}`, {now, allowRelative: true})).to.eql('1 hour ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 11:59'), {now, allowRelative: true})).to.eql('1 minute ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 11:55'), {now, allowRelative: true})).to.eql('5 minutes ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 11:15:00'), {now, allowRelative: true})).to.eql('45 minutes ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 11:10:00'), {now, allowRelative: true})).to.eql('1 hour ago');
 		});
 
 		it('should format hours-distant dates', () => {
-			expect(formatDate(`2016-04-10 11:00${timeZoneCode}`, {now, allowRelative: true})).to.eql('1 hour ago');
-			expect(formatDate(`2016-04-10 00:00${timeZoneCode}`, {now, allowRelative: true})).to.eql('12 hours ago');
-			expect(formatDate(`2016-04-9 20:00${timeZoneCode}`, {now, allowRelative: true})).to.eql('16 hours ago');
-			expect(formatDate(`2016-04-9 14:00${timeZoneCode}`, {now, allowRelative: true, displayTime: false})).to.eql('1 day ago');
-			expect(formatDate(`2016-04-9 14:00${timeZoneCode}`, {now, allowRelative: true, displayTime: true})).to.eql('1 day ago at 2:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 11:00'), {now, allowRelative: true})).to.eql('1 hour ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 00:00'), {now, allowRelative: true})).to.eql('12 hours ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-9 20:00'), {now, allowRelative: true})).to.eql('16 hours ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-9 14:00'), {now, allowRelative: true, displayTime: false})).to.eql('1 day ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-9 14:00'), {now, allowRelative: true, displayTime: true})).to.eql('1 day ago at 2:00 PM');
 		});
 
 		it('should format days-distant dates', () => {
-			expect(formatDate(`2016-04-09 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: false})).to.eql('1 day ago');
-			expect(formatDate(`2016-04-08 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: false})).to.eql('2 days ago');
-			expect(formatDate(`2016-04-06 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: false})).to.eql('Apr 06');
-			expect(formatDate(`2015-04-06 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: false})).to.eql('Apr 06, 2015');
+			expect(formatDate(appendTimeZoneCode('2016-04-09 13:00'), {now, allowRelative: true, displayTime: false})).to.eql('1 day ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 13:00'), {now, allowRelative: true, displayTime: false})).to.eql('2 days ago');
+			expect(formatDate(appendTimeZoneCode('2016-04-06 13:00'), {now, allowRelative: true, displayTime: false})).to.eql('Apr 06');
+			expect(formatDate(appendTimeZoneCode('2015-04-06 13:00'), {now, allowRelative: true, displayTime: false})).to.eql('Apr 06, 2015');
 
-			expect(formatDate(`2016-04-09 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: true})).to.eql('1 day ago at 1:00 PM');
-			expect(formatDate(`2016-04-08 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: true})).to.eql('2 days ago at 1:00 PM');
-			expect(formatDate(`2016-04-06 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: true})).to.eql('Apr 06, 1:00 PM');
-			expect(formatDate(`2015-04-06 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: true})).to.eql('Apr 06, 2015, 1:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-09 13:00'), {now, allowRelative: true, displayTime: true})).to.eql('1 day ago at 1:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 13:00'), {now, allowRelative: true, displayTime: true})).to.eql('2 days ago at 1:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-06 13:00'), {now, allowRelative: true, displayTime: true})).to.eql('Apr 06, 1:00 PM');
+			expect(formatDate(appendTimeZoneCode('2015-04-06 13:00'), {now, allowRelative: true, displayTime: true})).to.eql('Apr 06, 2015, 1:00 PM');
 		});
 
 		it('should not allow relative when in the past', () => {
-			expect(formatDate(`2016-04-10 11:59:50${timeZoneCode}`, {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Just now');
-			expect(formatDate(`2016-04-10 12:00:00${timeZoneCode}`, {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Just now');
-			expect(formatDate(`2016-04-09 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Yesterday');
-			expect(formatDate(`2016-04-08 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Apr 08');
-			expect(formatDate(`2016-04-06 13:00${timeZoneCode}`, {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Apr 06');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 11:59:50'), {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Just now');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 12:00:00'), {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Just now');
+			expect(formatDate(appendTimeZoneCode('2016-04-09 13:00'), {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Yesterday');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 13:00'), {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Apr 08');
+			expect(formatDate(appendTimeZoneCode('2016-04-06 13:00'), {now, allowRelative: true, displayTime: false, allowRelativeInDistantPast: false})).to.eql('Apr 06');
 		});
 	});
 
 	describe('absolute', () => {
-		const now = new Date(`2016-04-10 12:00:00${timeZoneCode}`);
+		const now = new Date(appendTimeZoneCode('2016-04-10 12:00:00'));
 
 		it('should format contextual days', () => {
-			expect(formatDate(`2016-04-09 0:00:01${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Yesterday');
-			expect(formatDate(`2016-04-09 23:59:59${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Yesterday');
-			expect(formatDate(`2016-04-10 0:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Today');
-			expect(formatDate(`2016-04-10 23:59:59${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Today');
-			expect(formatDate(`2016-04-11 0:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Tomorrow');
-			expect(formatDate(`2016-04-11 23:59:59${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Tomorrow');
-			expect(formatDate(`2016-04-08 0:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Apr 08');
-			expect(formatDate(`2016-04-08 23:59:59${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Apr 08');
-			expect(formatDate(`2015-04-07 0:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Apr 07, 2015');
-			expect(formatDate(`2015-04-07 23:59:59${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Apr 07, 2015');
-			expect(formatDate(`2016-04-11 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: true})).to.eql('Tomorrow at 12:00 PM');
-			expect(formatDate(`2016-04-10 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: true})).to.eql('Today at 12:00 PM');
-			expect(formatDate(`2016-04-09 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: true})).to.eql('Yesterday at 12:00 PM');
-			expect(formatDate(`2016-04-08 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: true})).to.eql('Apr 08, 12:00 PM');
-			expect(formatDate(`2015-04-07 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: true})).to.eql('Apr 07, 2015, 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-09 0:00:01'), {now, allowRelative: false, displayTime: false})).to.eql('Yesterday');
+			expect(formatDate(appendTimeZoneCode('2016-04-09 23:59:59'), {now, allowRelative: false, displayTime: false})).to.eql('Yesterday');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 0:00:00'), {now, allowRelative: false, displayTime: false})).to.eql('Today');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 23:59:59'), {now, allowRelative: false, displayTime: false})).to.eql('Today');
+			expect(formatDate(appendTimeZoneCode('2016-04-11 0:00:00'), {now, allowRelative: false, displayTime: false})).to.eql('Tomorrow');
+			expect(formatDate(appendTimeZoneCode('2016-04-11 23:59:59'), {now, allowRelative: false, displayTime: false})).to.eql('Tomorrow');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 0:00:00'), {now, allowRelative: false, displayTime: false})).to.eql('Apr 08');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 23:59:59'), {now, allowRelative: false, displayTime: false})).to.eql('Apr 08');
+			expect(formatDate(appendTimeZoneCode('2015-04-07 0:00:00'), {now, allowRelative: false, displayTime: false})).to.eql('Apr 07, 2015');
+			expect(formatDate(appendTimeZoneCode('2015-04-07 23:59:59'), {now, allowRelative: false, displayTime: false})).to.eql('Apr 07, 2015');
+			expect(formatDate(appendTimeZoneCode('2016-04-11 12:00:00'), {now, allowRelative: false, displayTime: true})).to.eql('Tomorrow at 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-10 12:00:00'), {now, allowRelative: false, displayTime: true})).to.eql('Today at 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-09 12:00:00'), {now, allowRelative: false, displayTime: true})).to.eql('Yesterday at 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 12:00:00'), {now, allowRelative: false, displayTime: true})).to.eql('Apr 08, 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2015-04-07 12:00:00'), {now, allowRelative: false, displayTime: true})).to.eql('Apr 07, 2015, 12:00 PM');
 		});
 
 		it('should format absolute outside of contextual', () => {
-			expect(formatDate(`2016-04-08 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Apr 08');
-			expect(formatDate(`2015-04-07 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Apr 07, 2015');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 12:00:00'), {now, allowRelative: false, displayTime: false})).to.eql('Apr 08');
+			expect(formatDate(appendTimeZoneCode('2015-04-07 12:00:00'), {now, allowRelative: false, displayTime: false})).to.eql('Apr 07, 2015');
 
-			expect(formatDate(`2016-04-08 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: true})).to.eql('Apr 08, 12:00 PM');
-			expect(formatDate(`2015-04-07 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: true})).to.eql('Apr 07, 2015, 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 12:00:00'), {now, allowRelative: false, displayTime: true})).to.eql('Apr 08, 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2015-04-07 12:00:00'), {now, allowRelative: false, displayTime: true})).to.eql('Apr 07, 2015, 12:00 PM');
 		});
 
 		it('should format drop year when current year', () => {
-			expect(formatDate(`2016-04-08 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Apr 08');
-			expect(formatDate(`2015-04-07 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: false})).to.eql('Apr 07, 2015');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 12:00:00'), {now, allowRelative: false, displayTime: false})).to.eql('Apr 08');
+			expect(formatDate(appendTimeZoneCode('2015-04-07 12:00:00'), {now, allowRelative: false, displayTime: false})).to.eql('Apr 07, 2015');
 
-			expect(formatDate(`2016-04-08 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: true})).to.eql('Apr 08, 12:00 PM');
-			expect(formatDate(`2015-04-07 12:00:00${timeZoneCode}`, {now, allowRelative: false, displayTime: true})).to.eql('Apr 07, 2015, 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 12:00:00'), {now, allowRelative: false, displayTime: true})).to.eql('Apr 08, 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2015-04-07 12:00:00'), {now, allowRelative: false, displayTime: true})).to.eql('Apr 07, 2015, 12:00 PM');
 		});
 
 		it('should format drop time when outside current year', () => {
-			expect(formatDate(`2016-04-08 12:00:00${timeZoneCode}`, {now, allowRelative: false})).to.eql('Apr 08, 12:00 PM');
-			expect(formatDate(`2015-04-07 12:00:00${timeZoneCode}`, {now, allowRelative: false})).to.eql('Apr 07, 2015');
+			expect(formatDate(appendTimeZoneCode('2016-04-08 12:00:00'), {now, allowRelative: false})).to.eql('Apr 08, 12:00 PM');
+			expect(formatDate(appendTimeZoneCode('2015-04-07 12:00:00'), {now, allowRelative: false})).to.eql('Apr 07, 2015');
 		});
 	});
 });

--- a/src/sdk/formatting/formatDateRange.test.ts
+++ b/src/sdk/formatting/formatDateRange.test.ts
@@ -1,33 +1,33 @@
 import { formatDateRange } from './formatDateRange';
 import expect = require('expect.js');
-import {timeZoneCode} from './testUtil';
+import {appendTimeZoneCode} from './testUtil';
 
 describe('formatDateRange', () => {
-	const now = new Date(`2016-04-10 12:00:00${timeZoneCode}`);
+	const now = new Date(appendTimeZoneCode('2016-04-10 12:00:00'));
 	const options = {
 		now,
 		separator: ' - '
 	};
 
 	it('can format date ranges', () => {
-		expect(formatDateRange(`2016-04-10 4:34:50${timeZoneCode}`, `2016-04-11 13:34:50${timeZoneCode}`, options)).to.eql('Today - Tomorrow');
-		expect(formatDateRange(`2016-04-10 0:34:50${timeZoneCode}`, `2016-04-11 0:34:50${timeZoneCode}`, options)).to.eql('Today - Tomorrow');
-		expect(formatDateRange(`2016-04-10 23:34:50${timeZoneCode}`, `2016-04-11 23:34:50${timeZoneCode}`, options)).to.eql('Today - Tomorrow');
-		expect(formatDateRange(`2016-04-6 4:34:50${timeZoneCode}`, `2016-04-7 13:34:50${timeZoneCode}`, options)).to.eql('Apr 06 - Apr 07');
-		expect(formatDateRange(`2015-04-6 4:34:50${timeZoneCode}`, `2015-04-7 13:34:50${timeZoneCode}`, options)).to.eql('Apr 06, 2015 - Apr 07, 2015');
-		expect(formatDateRange(`2016-04-10 4:34:50${timeZoneCode}`, `2016-04-11 13:34:50${timeZoneCode}`, {...options, requireStrict: true})).to.eql('Apr 10 - Apr 11');
+		expect(formatDateRange(appendTimeZoneCode('2016-04-10 4:34:50'), appendTimeZoneCode('2016-04-11 13:34:50'), options)).to.eql('Today - Tomorrow');
+		expect(formatDateRange(appendTimeZoneCode('2016-04-10 0:34:50'), appendTimeZoneCode('2016-04-11 0:34:50'), options)).to.eql('Today - Tomorrow');
+		expect(formatDateRange(appendTimeZoneCode('2016-04-10 23:34:50'), appendTimeZoneCode('2016-04-11 23:34:50'), options)).to.eql('Today - Tomorrow');
+		expect(formatDateRange(appendTimeZoneCode('2016-04-6 4:34:50'), appendTimeZoneCode('2016-04-7 13:34:50'), options)).to.eql('Apr 06 - Apr 07');
+		expect(formatDateRange(appendTimeZoneCode('2015-04-6 4:34:50'), appendTimeZoneCode('2015-04-7 13:34:50'), options)).to.eql('Apr 06, 2015 - Apr 07, 2015');
+		expect(formatDateRange(appendTimeZoneCode('2016-04-10 4:34:50'), appendTimeZoneCode('2016-04-11 13:34:50'), {...options, requireStrict: true})).to.eql('Apr 10 - Apr 11');
 	});
 
 	it('should return `start` without separator when no `end`', () => {
-		expect(formatDateRange(`2016-04-6 0:00:00${timeZoneCode}`, null, options)).to.eql('Apr 06');
-		expect(formatDateRange(`2016-04-6 23:59:59${timeZoneCode}`, null, options)).to.eql('Apr 06');
-		expect(formatDateRange(`2016-04-6 4:34:50${timeZoneCode}`, null, options)).to.eql('Apr 06');
-		expect(formatDateRange(`2016-04-6 14:34:50${timeZoneCode}`, undefined, options)).to.eql('Apr 06');
+		expect(formatDateRange(appendTimeZoneCode('2016-04-6 0:00:00'), null, options)).to.eql('Apr 06');
+		expect(formatDateRange(appendTimeZoneCode('2016-04-6 23:59:59'), null, options)).to.eql('Apr 06');
+		expect(formatDateRange(appendTimeZoneCode('2016-04-6 4:34:50'), null, options)).to.eql('Apr 06');
+		expect(formatDateRange(appendTimeZoneCode('2016-04-6 14:34:50'), undefined, options)).to.eql('Apr 06');
 	});
 
 	it('should return `end` without separator when no `start`', () => {
-		expect(formatDateRange(null, `2016-04-7 8:34:50${timeZoneCode}`, options)).to.eql('Apr 07');
-		expect(formatDateRange(undefined, `2016-04-7 18:34:50${timeZoneCode}`, options)).to.eql('Apr 07');
+		expect(formatDateRange(null, appendTimeZoneCode('2016-04-7 8:34:50'), options)).to.eql('Apr 07');
+		expect(formatDateRange(undefined, appendTimeZoneCode('2016-04-7 18:34:50'), options)).to.eql('Apr 07');
 	});
 
 	it('should return null when no `start` or `end`', () => {

--- a/src/sdk/formatting/formatTime.test.ts
+++ b/src/sdk/formatting/formatTime.test.ts
@@ -1,15 +1,20 @@
 import { formatTime } from './formatTime';
 import expect = require('expect.js');
-import {timeZoneCode} from './testUtil';
+import {appendTimeZoneCode, getTimeZoneCode} from './testUtil';
 
 describe('formatTime', () => {
 	it('can format times', () => {
-		expect(formatTime(`2016-04-10 4:34:50${timeZoneCode}`)).to.eql('4:34 AM');
-		expect(formatTime(`2016-04-10 13:34:50${timeZoneCode}`)).to.eql('1:34 PM');
+		expect(formatTime(appendTimeZoneCode('2016-04-10 4:34:50'))).to.eql('4:34 AM');
+		expect(formatTime(appendTimeZoneCode('2016-04-10 13:34:50'))).to.eql('1:34 PM');
 	});
 
-	it('can display timezone name', () => {
-		expect(formatTime(`2016-04-10 4:34:50${timeZoneCode}`, {showTimeZone: true})).to.eql('4:34 AM MST');
-		expect(formatTime(`2016-04-10 13:34:50${timeZoneCode}`, {showTimeZone: true})).to.eql('1:34 PM MST');
+	it('can display timezone name standard', () => {
+		const date = '2016-01-10 4:34:50';
+		expect(formatTime(appendTimeZoneCode(date), {showTimeZone: true})).to.eql(`04:34 AM ${getTimeZoneCode(new Date(date))}`);
+	});
+
+	it('can display timezone name dst', () => {
+		const date = '2016-07-10 13:34:50';
+		expect(formatTime(appendTimeZoneCode(date), {showTimeZone: true})).to.eql(`01:34 PM ${getTimeZoneCode(new Date(date))}`);
 	});
 });

--- a/src/sdk/formatting/formatTime.test.ts
+++ b/src/sdk/formatting/formatTime.test.ts
@@ -10,11 +10,11 @@ describe('formatTime', () => {
 
 	it('can display timezone name standard', () => {
 		const date = '2016-01-10 4:34:50';
-		expect(formatTime(appendTimeZoneCode(date), {showTimeZone: true})).to.eql(`04:34 AM ${getTimeZoneCode(new Date(date))}`);
+		expect(formatTime(appendTimeZoneCode(date), {showTimeZone: true})).to.eql(`4:34 AM ${getTimeZoneCode(new Date(date))}`);
 	});
 
 	it('can display timezone name dst', () => {
 		const date = '2016-07-10 13:34:50';
-		expect(formatTime(appendTimeZoneCode(date), {showTimeZone: true})).to.eql(`01:34 PM ${getTimeZoneCode(new Date(date))}`);
+		expect(formatTime(appendTimeZoneCode(date), {showTimeZone: true})).to.eql(`1:34 PM ${getTimeZoneCode(new Date(date))}`);
 	});
 });

--- a/src/sdk/formatting/formatTimeRange.test.ts
+++ b/src/sdk/formatting/formatTimeRange.test.ts
@@ -1,25 +1,25 @@
 import { formatTimeRange } from './formatTimeRange';
 import expect = require('expect.js');
-import {timeZoneCode} from './testUtil';
+import {appendTimeZoneCode} from './testUtil';
 
 describe('formatTimeRange', () => {
 	it('can format time ranges', () => {
-		expect(formatTimeRange(`2016-04-10 4:34:50${timeZoneCode}`, `2016-04-10 13:34:50${timeZoneCode}`)).to.eql('4:34 AM-1:34 PM');
+		expect(formatTimeRange(appendTimeZoneCode('2016-04-10 4:34:50'), appendTimeZoneCode('2016-04-10 13:34:50'))).to.eql('4:34 AM-1:34 PM');
 	});
 
 	it('should trim suffix when both produce same suffix', () => {
-		expect(formatTimeRange(`2016-04-10 4:34:50${timeZoneCode}`, `2016-04-10 8:34:50${timeZoneCode}`)).to.eql('4:34-8:34 AM');
-		expect(formatTimeRange(`2016-04-10 14:34:50${timeZoneCode}`, `2016-04-10 18:34:50${timeZoneCode}`)).to.eql('2:34-6:34 PM');
+		expect(formatTimeRange(appendTimeZoneCode('2016-04-10 4:34:50'), appendTimeZoneCode('2016-04-10 8:34:50'))).to.eql('4:34-8:34 AM');
+		expect(formatTimeRange(appendTimeZoneCode('2016-04-10 14:34:50'), appendTimeZoneCode('2016-04-10 18:34:50'))).to.eql('2:34-6:34 PM');
 	});
 
 	it('should return `start` without separator when no `end`', () => {
-		expect(formatTimeRange(`2016-04-10 4:34:50${timeZoneCode}`, null)).to.eql('4:34 AM');
-		expect(formatTimeRange(`2016-04-10 14:34:50${timeZoneCode}`, undefined)).to.eql('2:34 PM');
+		expect(formatTimeRange(appendTimeZoneCode('2016-04-10 4:34:50'), null)).to.eql('4:34 AM');
+		expect(formatTimeRange(appendTimeZoneCode('2016-04-10 14:34:50'), undefined)).to.eql('2:34 PM');
 	});
 
 	it('should return `end` without separator when no `start`', () => {
-		expect(formatTimeRange(null, `2016-04-10 8:34:50${timeZoneCode}`)).to.eql('8:34 AM');
-		expect(formatTimeRange(undefined, `2016-04-10 18:34:50${timeZoneCode}`)).to.eql('6:34 PM');
+		expect(formatTimeRange(null, appendTimeZoneCode('2016-04-10 8:34:50'))).to.eql('8:34 AM');
+		expect(formatTimeRange(undefined, appendTimeZoneCode('2016-04-10 18:34:50'))).to.eql('6:34 PM');
 	});
 
 	it('should return null when no `start` or `end`', () => {

--- a/src/sdk/formatting/formatTimeRange.ts
+++ b/src/sdk/formatting/formatTimeRange.ts
@@ -22,10 +22,9 @@ const isSameTimeFrame = (start: Date, end: Date): boolean => {
 };
 
 const formatNoSuffix = (value: Date) => {
-	const hours = value.getHours();
-	if (hours >= 12) {
+	if (!isAM(value)) {
 		value = new Date(value);
-		value.setHours(hours - 12);
+		value.setHours((value.getHours() + 12) % 24);
 	}
 
 	return trimPrecedingZero(noSuffixFormat.format(value));

--- a/src/sdk/formatting/getDateFormat.ts
+++ b/src/sdk/formatting/getDateFormat.ts
@@ -1,5 +1,4 @@
 const isInTest = typeof global['it'] === 'function';
-
-const timeZone = isInTest && { timeZone: 'America/Phoenix' };
+const timeZone = isInTest && { timeZone: process.env.TIME_ZONE || 'UTC' };
 
 export const getDateFormat = args => new Intl.DateTimeFormat('en', Object.assign(args, timeZone));

--- a/src/sdk/formatting/testUtil.ts
+++ b/src/sdk/formatting/testUtil.ts
@@ -1,3 +1,22 @@
-Date.prototype.getTimezoneOffset = function () { return 420; };
+import {getDateFormat} from './getDateFormat';
 
-export const timeZoneCode = ' UTC-7';
+export const getTimeZoneCode = (date: Date): string => {
+	const formatter = getDateFormat({hour: '2-digit', minute: '2-digit', timeZoneName: 'short'});
+	const localizedDate = formatter.format(date);
+	const parts = localizedDate.split(' ');
+	return parts[parts.length - 1];
+};
+
+export const appendTimeZoneCode = (date: string): string => {
+	return `${date} ${getTimeZoneCode(new Date(date))}`;
+};
+
+const minute = 6e4;
+
+Date.prototype.getTimezoneOffset = function() {
+	const formatter = getDateFormat({year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit', timeZoneName: 'short'});
+	const localizedDate = formatter.format(this);
+	const parts = localizedDate.split(' ');
+	parts[parts.length - 1] = 'UTC';
+	return Math.floor(this.getTime() / minute) - Math.floor(new Date(parts.join(' ')).getTime() / minute);
+};


### PR DESCRIPTION
With these changes, we can pass in a specific time zone in the CLI tests, but still let PhantomJS use the default (UTC) in the vNext web tests. This also adds the ability to test DST, which wasn't working previously.