### PR TITLE
SF-6634: Admin access token not invalidated can lead to Account takeover for previous admin

### DIFF
--- a/src/sdk/http/http-client.ts
+++ b/src/sdk/http/http-client.ts
@@ -169,6 +169,7 @@ export abstract class HttpClient<TRequest, TResponse> implements IHttpClient {
 					url: HttpClient.getUrl('connect/logout', this.baseAddress),
 					method: 'GET',
 					headers: {
+						'Authorization': `Bearer ${this.token.accessToken}`,
 						'Accept': 'application/json',
 						'Revoke-Tokens': revokeTokens
 					}

--- a/src/sdk/http/http-client.ts
+++ b/src/sdk/http/http-client.ts
@@ -164,11 +164,13 @@ export abstract class HttpClient<TRequest, TResponse> implements IHttpClient {
 	async logout(): Promise<any> {
 		return await new Promise<any>(resolve => {
 			if (this.isLoggedIn) {
+				const revokeTokens: string = [this.token.accessToken, this.token.refreshToken].filter(Boolean).join(',');
 				this.executeJsonRequest(<any>{
 					url: HttpClient.getUrl('connect/logout', this.baseAddress),
 					method: 'GET',
 					headers: {
-						'Accept': 'application/json'
+						'Accept': 'application/json',
+						'Revoke-Tokens': revokeTokens
 					}
 				}, resolve);
 			} else {


### PR DESCRIPTION
Marking this as a draft since it is closely tied with [this `skysync-vnext` PR](https://github.com/portalarchitects/skysync-vnext/pull/2728).