### PR TITLE
Fix types declarations

### DIFF
--- a/build/create-types-plugin.js
+++ b/build/create-types-plugin.js
@@ -11,7 +11,7 @@ const CreateTypesPlugin = (function() {
 			const fullPath = path.join(__dirname, `../publish/sdk.d.ts`);
 			fs.writeFileSync(
 				fullPath,
-				`export * from './types/sdk/index.d.ts';`
+				`export * from './types/sdk';`
 			);
 		});
 	};

--- a/build/webpack.js
+++ b/build/webpack.js
@@ -56,7 +56,7 @@ module.exports = {
 						return deps;
 					}, {}),
 				main: './sdk.js',
-				types: './types/sdk.d.ts',
+				types: './sdk.d.ts',
 			},
 			packageJsonPath
 		),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "email": "support@skysync.com"
   },
   "main": "./dist/sdk.js",
-  "types": "./dist/types/sdk.d.ts",
+  "types": "./dist/sdk.d.ts",
   "author": {
     "name": "SkySync",
     "email": "developers@skysync.com"

--- a/src/sdk/models/index.ts
+++ b/src/sdk/models/index.ts
@@ -1,5 +1,6 @@
 export * from './accountMaps';
 export * from './auditCategories';
+export * from './base';
 export * from './connections';
 export * from './contentCategories';
 export * from './conventions';


### PR DESCRIPTION
The types declarations were getting output incorrectly, which was causing VS Code to import everything as `any` rather than picking up the actual type definitions.