### PR TITLE
CL99-54/CL99-57

### DIFF
--- a/build/webpack.js
+++ b/build/webpack.js
@@ -25,7 +25,7 @@ console.log('Creating version ' + version);
 const includeDeps = ['querystring-es3'];
 
 module.exports = {
-	mode: 'production',
+	mode: process.env.NODE_ENV !== 'production' ? 'development' : 'production',
 	entry: {
 		sdk: path.resolve(__dirname, '../src/sdk/index.ts')
 	},
@@ -73,4 +73,5 @@ module.exports = {
 		{ 'querystring': 'querystring-es3' },
 		nodeExternals()
 	],
+	...(process.env.NODE_ENV !== 'production' ? { devtool: 'eval-source-map' } : undefined)
 };

--- a/package.json
+++ b/package.json
@@ -40,9 +40,12 @@
   "scripts": {
     "clean": "rimraf dist publish",
     "build:tsc": "tsc -p ./src",
+    "build:tsc-dev": "tsc -p ./src/tsconfig.development.json",
     "build:webpack": "webpack --config ./build/webpack.js",
     "build:publish": "rimraf dist/sdk && ncp ./publish ./dist && rimraf dist/.npmrc dist/package.json",
     "build": "npm run clean && npm run build:tsc && npm run build:webpack && npm run build:publish",
+    "build-dev": "cross-env NODE_ENV=development npm run clean && npm run build:tsc-dev && npm run build:webpack && npm run build:publish",
+    "skysync-cli-dbg": "node --inspect-brk ./bin/skysync.js",
     "prepare": "npm run build",
     "lint": "eslint -c .eslintrc.js --ext .ts src",
     "lint:fix": "npm run lint -- --fix",

--- a/src/commands/jobs/folders.ts
+++ b/src/commands/jobs/folders.ts
@@ -4,7 +4,7 @@ import { itemOutputFormat } from './util';
 
 
 export = {
-	command: 'folders <id>',
+	command: 'folders [id]',
 	desc: 'Show transfer folders',
 	builder: yargs => {
 		yargs.options({

--- a/src/commands/transferAuditCategories/add.ts
+++ b/src/commands/transferAuditCategories/add.ts
@@ -68,6 +68,7 @@ export = {
 
 			if (argv.optionsInput) {
 				auditCategory = await readJsonInput();
+				auditCategory.name = argv.name;
 			}
 			auditCategory = await client.transferAuditCategories.add(auditCategory, {
 				fields: 'all'

--- a/src/sdk/http/fetch-client.ts
+++ b/src/sdk/http/fetch-client.ts
@@ -57,6 +57,10 @@ export class FetchHttpClient extends HttpClient<any, any> {
 	protected getStatusCode(response: any): number {
 		return response.status;
 	}
+
+	protected getHeadersValue(headers: any, key: string): string {
+		return headers.get(key);
+	}
 	
 	async download(path: string, handler: (fileName: string, output: Readable) => Promise<any>, token?: CancellationToken) {
 		return await new Promise(async (resolve, reject) => {

--- a/src/sdk/http/fetch-client.ts
+++ b/src/sdk/http/fetch-client.ts
@@ -73,13 +73,12 @@ export class FetchHttpClient extends HttpClient<any, any> {
 				const response = await this.fetch(url, options);
 				let __this = this;
 				
-				response.on('response', function (response) {
-					if (response.statusCode >= 400) {
-						reject(new Error('The requested path could not be retrieved from the server.'));
-						return;
-					}
-					return resolve(handler(__this.parseContentDispositionHeader(response.headers), response));
-				});
+				if (response.status >= 400) {
+					reject(new Error('The requested path could not be retrieved from the server.'));
+					return;
+				}
+				return resolve(handler(__this.parseContentDispositionHeader(response.headers), response.body));
+				
 			} catch (e) {
 				reject(e);
 			}

--- a/src/sdk/http/http-client.ts
+++ b/src/sdk/http/http-client.ts
@@ -228,6 +228,8 @@ export abstract class HttpClient<TRequest, TResponse> implements IHttpClient {
 	protected abstract executeJsonRequest(req: TRequest, callback: (err: any, response: TResponse, body: string) => void, token?: CancellationToken);
 
 	protected abstract getStatusCode(response: TResponse): number;
+	
+	protected abstract getHeadersValue(headers: any, key: string): string;
 
 	private getError(err, response: TResponse, body: string) {
 		if (err) {
@@ -283,8 +285,8 @@ export abstract class HttpClient<TRequest, TResponse> implements IHttpClient {
 						return resolve(null);
 					}
 
-					const contentType = response.headers && response.headers.get('content-type');
-					const jsonResponse = contentType && contentType.indexOf('application/json') >= 0;
+					const contentType = response.headers && this.getHeadersValue(response.headers, 'content-type');
+					const jsonResponse = !contentType || contentType.indexOf('application/json') >= 0;
 					if (!body || body.length === 0) {
 						return resolve(jsonResponse ? {} : '');
 					}
@@ -353,7 +355,7 @@ export abstract class HttpClient<TRequest, TResponse> implements IHttpClient {
 	}
 	
 	protected parseContentDispositionHeader(headers: any): string {
-		let contentDisposition = headers.get('content-disposition');
+		let contentDisposition = this.getHeadersValue(headers, 'content-disposition');
 		if (!contentDisposition) {
 			return undefined;
 		}

--- a/src/sdk/http/http-client.ts
+++ b/src/sdk/http/http-client.ts
@@ -283,7 +283,8 @@ export abstract class HttpClient<TRequest, TResponse> implements IHttpClient {
 						return resolve(null);
 					}
 
-					const jsonResponse = !response.headers || !response.headers['content-type'] || response.headers['content-type'].indexOf('application/json') >= 0;
+					const contentType = response.headers && response.headers.get('content-type');
+					const jsonResponse = contentType && contentType.indexOf('application/json') >= 0;
 					if (!body || body.length === 0) {
 						return resolve(jsonResponse ? {} : '');
 					}
@@ -352,7 +353,7 @@ export abstract class HttpClient<TRequest, TResponse> implements IHttpClient {
 	}
 	
 	protected parseContentDispositionHeader(headers: any): string {
-		let contentDisposition = headers['content-disposition'];
+		let contentDisposition = headers.get('content-disposition');
 		if (!contentDisposition) {
 			return undefined;
 		}

--- a/src/sdk/http/test-client.ts
+++ b/src/sdk/http/test-client.ts
@@ -22,6 +22,10 @@ export class TestHttpClient extends HttpClient<any, any> implements IHttpClient 
 	
 	protected getStatusCode(response: any): number {
 		return response.statusCode;
+	}	
+
+	protected getHeadersValue(headers: any, key: string): string {
+		return headers[key];
 	}
 
 	protected executeJsonRequest(req: any, callback: (err: any, response?: any, body?: string) => void) {

--- a/src/tsconfig.development.json
+++ b/src/tsconfig.development.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.options",
+	"exclude": [
+		"node_modules",
+		"sdk/http/test-client.ts",
+		"**/*.test.ts"
+	],
+	"compilerOptions": {
+		"sourceMap": true
+	}
+}


### PR DESCRIPTION
1. [CL99-54](https://skysync.atlassian.net/browse/CL99-54)  - add audit category not working when JSON run from cmd line:
* fix 'transfer-audit-categories add --options-input --name={{name}}' command. the mandatory --name option must always override the JSON name field if present
2. [CL99-56](https://skysync.atlassian.net/browse/CL99-56) downloading a cluster node installation package giving error:
* fix remaining issues after switching to node-fetch - see d728919 ("Upgrade and trim dependencies (#156)", 2020-12-23)
3. added build-dev and skysync-cli-dbg npm scripts to simplify debugging.

