### PR TITLE
SF-9179 | added POST functionality to the get connection items call to handle long URLs

### DIFF
--- a/src/sdk/http/http-client.ts
+++ b/src/sdk/http/http-client.ts
@@ -19,6 +19,8 @@ export interface IAuthorizationToken {
 export interface IHttpClient {
 	isLoggedIn: boolean;
 
+	shouldPost(path: string, params: any): boolean;
+
 	authenticate(): Promise<any>;
 
 	logout(): Promise<any>;
@@ -146,6 +148,10 @@ export abstract class HttpClient<TRequest, TResponse> implements IHttpClient {
 
 	get isLoggedIn(): boolean {
 		return !this.isAuthRequired || Boolean(this.accessToken);
+	}
+
+	shouldPost(path: string, params: any): boolean {
+		return HttpClient.getUrl(path, this.apiUrl, params).length > 2000;
 	}
 
 	async authenticate(): Promise<any> {

--- a/src/sdk/resources/connections.ts
+++ b/src/sdk/resources/connections.ts
@@ -84,9 +84,9 @@ export class ConnectionItemsResource extends BaseResource {
 		let result;
 		const paramList = this.mergeDefaultParams(params);
 		if(canPost && this.httpClient.shouldPost(href, paramList)) {
-			var parameters = {}, body = {};
+			let parameters = {}, body = '';
 			for (const param in paramList) {
-				if (param == "token") {
+				if (param === 'token') {
 					body = paramList[param];
 				} else {
 					parameters[param] = paramList[param];


### PR DESCRIPTION
when passing the next page token for listing items from a connection the "Load More" link sent the data in the query sting as a GET.  DropBox had next page tokens that would make the URL too long and a http status of 414 was returned.  The code will now look at the length of the URL and perform a POST of the token.