### PR TITLE
ACT-1109 | Updating formatCurrency function

### DIFF
--- a/src/sdk/formatting/formatCurrency.test.ts
+++ b/src/sdk/formatting/formatCurrency.test.ts
@@ -44,17 +44,8 @@ describe('formatCurrency', () => {
 	});
 
 	it('can format whole units only', () => {
-		expect(formatCurrency(1042758.2426345, {
-			locale: 'en',
-			currency: 'USD'
-		}, true)).to.eql('$1,042,758');
-		expect(formatCurrency(1042758.25, {
-			locale: 'en',
-			currency: 'USD'
-		}, true)).to.eql('$1,042,758');
-		expect(formatCurrency(1042758.2, {
-			locale: 'en',
-			currency: 'USD'
-		}, true)).to.eql('$1,042,758');
+		expect(formatCurrency(1042758.2426345, {wholeUnitsOnly : true })).to.eql('$1,042,758');
+		expect(formatCurrency(1042758.25, {wholeUnitsOnly : true })).to.eql('$1,042,758');
+		expect(formatCurrency(1042758.2, {wholeUnitsOnly : true })).to.eql('$1,042,758');
 	});
 });

--- a/src/sdk/formatting/formatCurrency.test.ts
+++ b/src/sdk/formatting/formatCurrency.test.ts
@@ -22,18 +22,39 @@ describe('formatCurrency', () => {
 	});
 
 	it('can format other currencies', () => {
-		expect(formatCurrency(1042758.2426345, 'de-DE', 'EUR')).to.eql('1.042.758,24\xa0€');
-		expect(formatCurrency(1042758.2426345, 'ja-JP', 'JPY')).to.eql('￥1,042,758');
+		expect(formatCurrency(1042758.2426345, {
+			locale: 'de-DE',
+			currency: 'EUR'
+		})).to.eql('1.042.758,24\xa0€');
+		expect(formatCurrency(1042758.2426345, {
+			locale: 'ja-JP',
+			currency: 'JPY'
+		})).to.eql('￥1,042,758');
 	});
 
 	it('can format whole units only', () => {
-		expect(formatCurrency(1042758.2426345, 'de-DE', 'EUR')).to.eql('1.042.758,24\xa0€');
-		expect(formatCurrency(1042758.2426345, 'ja-JP', 'JPY')).to.eql('￥1,042,758');
+		expect(formatCurrency(1042758.2426345, {
+			locale: 'de-DE',
+			currency: 'EUR'
+		})).to.eql('1.042.758,24\xa0€');
+		expect(formatCurrency(1042758.2426345, {
+			locale: 'ja-JP',
+			currency: 'JPY'
+		})).to.eql('￥1,042,758');
 	});
 
 	it('can format whole units only', () => {
-		expect(formatCurrency(1042758.2426345, 'en', 'USD', true)).to.eql('$1,042,758');
-		expect(formatCurrency(1042758.25, 'en', 'USD', true)).to.eql('$1,042,758');
-		expect(formatCurrency(1042758.2, 'en', 'USD', true)).to.eql('$1,042,758');
+		expect(formatCurrency(1042758.2426345, {
+			locale: 'en',
+			currency: 'USD'
+		}, true)).to.eql('$1,042,758');
+		expect(formatCurrency(1042758.25, {
+			locale: 'en',
+			currency: 'USD'
+		}, true)).to.eql('$1,042,758');
+		expect(formatCurrency(1042758.2, {
+			locale: 'en',
+			currency: 'USD'
+		}, true)).to.eql('$1,042,758');
 	});
 });

--- a/src/sdk/formatting/formatCurrency.ts
+++ b/src/sdk/formatting/formatCurrency.ts
@@ -4,10 +4,10 @@ export type CurrencyFormatOptions = {
 	currency?: string;
 };
 
-export const formatCurrency = (number: number, options?: CurrencyFormatOptions, wholeUnitsOnly: boolean = false): string => {
-	const formatter = new Intl.NumberFormat(options?.locale ?? 'en', {
+export const formatCurrency = (number: number, options: CurrencyFormatOptions = { locale: 'en', currency: 'USD' }, wholeUnitsOnly: boolean = false): string => {
+	const formatter = new Intl.NumberFormat(options.locale, {
 		style: 'currency',
-		currency: options?.currency ?? 'USD',
+		currency: options.currency,
 		minimumFractionDigits: wholeUnitsOnly ? 0 : undefined,
 		maximumFractionDigits: wholeUnitsOnly ? 0 : undefined
 	});

--- a/src/sdk/formatting/formatCurrency.ts
+++ b/src/sdk/formatting/formatCurrency.ts
@@ -2,14 +2,15 @@
 export type CurrencyFormatOptions = { 
 	locale?: string;
 	currency?: string;
+	wholeUnitsOnly?: boolean;
 };
 
-export const formatCurrency = (number: number, options: CurrencyFormatOptions = { locale: 'en', currency: 'USD' }, wholeUnitsOnly: boolean = false): string => {
-	const formatter = new Intl.NumberFormat(options.locale, {
+export const formatCurrency = (number: number, options?: CurrencyFormatOptions): string => {
+	const formatter = new Intl.NumberFormat(options?.locale ?? 'en', {
 		style: 'currency',
-		currency: options.currency,
-		minimumFractionDigits: wholeUnitsOnly ? 0 : undefined,
-		maximumFractionDigits: wholeUnitsOnly ? 0 : undefined
+		currency: options?.currency ?? 'USD',
+		minimumFractionDigits: options?.wholeUnitsOnly ? 0 : undefined,
+		maximumFractionDigits: options?.wholeUnitsOnly ? 0 : undefined
 	});
 
 	if (!Boolean(number) || isNaN(number)) {

--- a/src/sdk/formatting/formatCurrency.ts
+++ b/src/sdk/formatting/formatCurrency.ts
@@ -1,9 +1,19 @@
-import { formatNumber } from './formatNumber';
 
-export const formatCurrency = (number: number, locale: string = 'en', currency: string = 'USD', wholeUnitsOnly: boolean = false): string =>
-	formatNumber(number, null, new Intl.NumberFormat(locale, {
+export type CurrencyFormatOptions = { 
+	locale?: string;
+	currency?: string;
+};
+
+export const formatCurrency = (number: number, options?: CurrencyFormatOptions, wholeUnitsOnly: boolean = false): string => {
+	const formatter = new Intl.NumberFormat(options?.locale ?? 'en', {
 		style: 'currency',
-		currency,
+		currency: options?.currency ?? 'USD',
 		minimumFractionDigits: wholeUnitsOnly ? 0 : undefined,
 		maximumFractionDigits: wholeUnitsOnly ? 0 : undefined
-	}));
+	});
+
+	if (!Boolean(number) || isNaN(number)) {
+		number = 0;
+	}
+	return formatter.format(number);
+};

--- a/src/sdk/formatting/formatNumber.ts
+++ b/src/sdk/formatting/formatNumber.ts
@@ -12,7 +12,7 @@ export type NumberFormatOptions = {
 	unit?: string;
 };
 
-export const formatNumber = (number: number, options?: NumberFormatOptions, formatter: Intl.NumberFormat = numberFormatter): string => {
+export const formatNumber = (number: number, options?: NumberFormatOptions): string => {
 	if (!Boolean(number) || isNaN(number)) {
 		number = 0;
 	}
@@ -32,7 +32,7 @@ export const formatNumber = (number: number, options?: NumberFormatOptions, form
 		}
 	}
 
-	let output = formatter.format(sign * number);
+	let output = numberFormatter.format(sign * number);
 	if (unit) {
 		output = formatUnit(output, unit, options?.separator);
 	}


### PR DESCRIPTION
- Parameterizing locale and currency as an optional CurrencyFormatOptions object.
- Removing NumberFormatter param from formatNumbers.
- Simplifying code in formatCurrency.