### PR TITLE
ACT-965: Fix singular names for action types resource

### DIFF
--- a/src/sdk/resources/policyActionTypes.ts
+++ b/src/sdk/resources/policyActionTypes.ts
@@ -4,6 +4,6 @@ import { PolicyActionDescriptor } from '../models';
 
 export class PolicyActionTypesResource extends Resource<PolicyActionDescriptor> {
 	constructor(httpClient: IHttpClient) {
-		super(httpClient, 'policy_action_type', 'policy_action_type', 'policy_action_types', 'policy_action_types', 'policies/action_types');
+		super(httpClient, 'policy_action_type', 'policy_action_types', 'policy_action_type', 'policy_action_types', 'policies/action_types');
 	}
 }


### PR DESCRIPTION
Arguments for singular/plural were mixed up. We didn't see this before because we were always using the list (plural) versions. Need singular for ACT-965 ui.

I tested the singular and plural of this in ACT and it works correctly now with this PR.