### PR TITLE
ACT-2766 | Cobalt MVP | Session tokens do not expire on logout

### DIFF
--- a/src/sdk/http/http-client.ts
+++ b/src/sdk/http/http-client.ts
@@ -166,14 +166,12 @@ export abstract class HttpClient<TRequest, TResponse> implements IHttpClient {
 	async logout(): Promise<void> {
 		return await new Promise<void>(resolve => {
 			if (this.isLoggedIn) {
-				const revokeTokens: string = [this.token.accessToken, this.token.refreshToken].filter(Boolean).join(',');
 				this.executeJsonRequest(<any>{
 					url: HttpClient.getUrl('connect/logout', this.baseAddress),
 					method: 'GET',
 					headers: {
 						'Authorization': `Bearer ${this.token.accessToken}`,
-						'Accept': 'application/json',
-						'Revoke-Tokens': revokeTokens
+						'Accept': 'application/json'
 					}
 				}, resolve);
 			} else {


### PR DESCRIPTION
Removing Revoke-Tokens header since the related logic is being removed from [skysync-vnext in this PR](https://github.com/portalarchitects/skysync-vnext/pull/3726).