### PR TITLE
Add GitHub Actions test workflow to replace Azure Pipelines test step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '16.16.0'
+
+      - run: npm install
+
+      - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16.16.0'
+          node-version: '18.18.0'
 
       - run: npm install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.18.0'
+          node-version: '16.16.0'
 
       - run: npm install
 


### PR DESCRIPTION
Converts the test portion of azure-pipelines.yml to a GitHub Actions workflow that runs on push/PR to master/main. Preserves the same Node.js version (16.16.0) and test command.

https://claude.ai/code/session_01QTcmtN8U4ZAqZkk8xN56KS
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/portalarchitects/skysync-cli/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
