### PR TITLE
ACT-7255 | Bump serialize-javascript to 7.0.5 via npm override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Development Commands
+
+- **Build:** `npm run build` (clean + tsc + webpack + publish artifacts)
+- **Dev build:** `npm run build-dev` (includes source maps)
+- **TypeScript only:** `npm run build:tsc`
+- **Lint:** `npm run lint` / `npm run lint:fix`
+- **Test:** `npm test` (runs lint then mocha)
+- **Run single test file:** `npx mocha --require ts-node/register src/path/to/file.test.ts`
+- **Local CLI:** `npm link` then `skysync-cli --help`
+
+## Architecture
+
+This is a TypeScript CLI tool and SDK for the SkySync file sync/migration platform. Three layers:
+
+**CLI Layer** (`src/commands/`) — Yargs command modules organized by domain (users/, jobs/, connections/, etc.). Parent commands use `.commandDir()` to auto-load subcommands. Commands export `{command, desc, builder, handler}`. The `runCommand(argv, handler)` utility in `src/util/command.ts` creates the SDK client and output formatter.
+
+**SDK Layer** (`src/sdk/`) — `SkySyncClient` (`src/sdk/client.ts`) is the facade with lazy-loaded resource getters. 60+ resource classes in `src/sdk/resources/` inherit from `Resource<T>` or `PagedResource<T>` (base class in `resource.ts`). Models live in `src/sdk/models/`.
+
+**HTTP Layer** (`src/sdk/http/`) — `HttpClient` handles auth, errors, and request construction. `FetchClient` is the production implementation using node-fetch. `TestHttpClient` is the mock for unit tests.
+
+**Entry point:** `bin/skysync.js` → `src/cli.ts` (Liftoff bootstraps config loading, Yargs parses commands).
+
+**SDK bundling:** Webpack bundles `src/sdk/index.ts` into `publish/sdk.js` as a separate `@skysync/sdk` package.
+
+## Code Style
+
+- **Indentation:** Tabs (enforced by ESLint)
+- **Quotes:** Single quotes
+- **Semicolons:** Required
+- **Member delimiters:** Semicolons (not commas) in interfaces/types
+- **Brace style:** 1tbs (one true brace style)
+- **No `console.log`** — use `console.warn`, `console.error`, etc.
+- **No `var`** — use `const`/`let`
+- **Strict equality** (`===`/`!==`) with smart exceptions
+- **No bitwise operators**
+- **TypeScript:** `noUnusedLocals` and `noUnusedParameters` are enabled
+
+## Testing
+
+- **Framework:** Mocha + expect.js
+- **Test files:** Co-located as `*.test.ts` alongside source files
+- **Mock HTTP:** Use `TestHttpClient` from `src/sdk/http/test-client.ts` — call `addPendingResponse()` to queue responses, `expectLastRequest()` to verify requests
+- **Test tsconfig:** `src/tsconfig.test.json` (includes test files; main tsconfig excludes them)
+
+## Configuration
+
+CLI options can come from (in precedence order):
+1. Command-line arguments
+2. Environment variables (`SKYSYNC_*` prefix)
+3. `skysync-cli.json` file (searched up the directory hierarchy via Liftoff)
+
+## CI
+
+Azure DevOps pipeline (`azure-pipelines.yml`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4031,15 +4031,6 @@
 				}
 			]
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -4218,26 +4209,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/safe-regex-test": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -4320,13 +4291,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/shallow-clone": {
@@ -6216,7 +6187,7 @@
 				"globby": "^13.1.1",
 				"normalize-path": "^3.0.0",
 				"schema-utils": "^4.0.0",
-				"serialize-javascript": "^6.0.0"
+				"serialize-javascript": "^7.0.5"
 			},
 			"dependencies": {
 				"globby": {
@@ -7749,7 +7720,7 @@
 				"log-symbols": "^4.1.0",
 				"minimatch": "^5.1.6",
 				"ms": "^2.1.3",
-				"serialize-javascript": "^6.0.2",
+				"serialize-javascript": "^7.0.5",
 				"strip-json-comments": "^3.1.1",
 				"supports-color": "^8.1.1",
 				"workerpool": "^6.5.1",
@@ -8094,15 +8065,6 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -8214,12 +8176,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true
-		},
 		"safe-regex-test": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -8281,13 +8237,10 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-			"dev": true,
-			"requires": {
-				"randombytes": "^2.1.0"
-			}
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+			"dev": true
 		},
 		"shallow-clone": {
 			"version": "3.0.1",
@@ -8479,7 +8432,7 @@
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^4.3.0",
-				"serialize-javascript": "^6.0.2",
+				"serialize-javascript": "^7.0.5",
 				"terser": "^5.31.1"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
 		"skysync-cli": "bin/skysync.js"
 	},
 	"overrides": {
-		"glob": "^10.5.0"
+		"glob": "^10.5.0",
+		"serialize-javascript": "^7.0.5"
 	},
 	"dependencies": {
 		"clifflite": "^0.0.4",


### PR DESCRIPTION
Resolves dependabot alerts #59 (RCE via RegExp.flags/Date.toISOString) and #64 (CPU exhaustion DoS). 

Also adds CLAUDE.md for Claude Code.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>